### PR TITLE
Refactor GetX controllers to explicit Rx types

### DIFF
--- a/lib/modules/ai_pricing/pricing_controller.dart
+++ b/lib/modules/ai_pricing/pricing_controller.dart
@@ -13,7 +13,7 @@ class PricingController extends GetxController {
   final AuctionsRepository auctionsRepository;
   final SettingsRepository settingsRepository;
 
-  final isCalculating = false.obs;
+  final RxBool isCalculating = RxBool(false);
   final Rxn<PricingResult> result = Rxn<PricingResult>();
   final Rxn<PricingRequest> lastRequest = Rxn<PricingRequest>();
 

--- a/lib/modules/auction_home/auction_controller.dart
+++ b/lib/modules/auction_home/auction_controller.dart
@@ -12,9 +12,9 @@ class AuctionController extends GetxController {
   final AuctionsRepository auctionsRepository;
   final SettingsRepository settingsRepository;
 
-  final auctions = <Auction>[].obs;
-  final products = <int, Product>{}.obs;
-  final isLoading = false.obs;
+  final RxList<Auction> auctions = RxList<Auction>([]);
+  final RxMap<int, Product> products = RxMap<int, Product>({});
+  final RxBool isLoading = RxBool(false);
 
   @override
   void onInit() {

--- a/lib/modules/auth/auth_controller.dart
+++ b/lib/modules/auth/auth_controller.dart
@@ -29,15 +29,15 @@ class AuthController extends GetxController {
   late final TextEditingController registerConfirmController;
   late final TextEditingController otpController;
 
-  final stage = AuthStage.login.obs;
-  final rememberMe = true.obs;
-  final obscurePassword = true.obs;
-  final acceptTerms = true.obs;
-  final isLoading = false.obs;
-  final isLoggedIn = false.obs;
-  final isGuest = false.obs;
-  final canResendCode = false.obs;
-  final countdown = 30.obs;
+  final Rx<AuthStage> stage = Rx<AuthStage>(AuthStage.login);
+  final RxBool rememberMe = RxBool(true);
+  final RxBool obscurePassword = RxBool(true);
+  final RxBool acceptTerms = RxBool(true);
+  final RxBool isLoading = RxBool(false);
+  final RxBool isLoggedIn = RxBool(false);
+  final RxBool isGuest = RxBool(false);
+  final RxBool canResendCode = RxBool(false);
+  final RxInt countdown = RxInt(30);
   final authError = RxnString();
 
   Timer? _timer;

--- a/lib/modules/catalog/watch_detail_controller.dart
+++ b/lib/modules/catalog/watch_detail_controller.dart
@@ -13,10 +13,10 @@ class WatchDetailController extends GetxController {
   final SettingsRepository settingsRepository;
 
   final watch = Rxn<WatchItem>();
-  final colorIndex = 0.obs;
-  final selectedSize = ''.obs;
-  final isProcessing = false.obs;
-  final isFavorite = false.obs;
+  final RxInt colorIndex = RxInt(0);
+  final RxString selectedSize = RxString('');
+  final RxBool isProcessing = RxBool(false);
+  final RxBool isFavorite = RxBool(false);
 
   @override
   void onInit() {

--- a/lib/modules/discounts_nearby/discounts_controller.dart
+++ b/lib/modules/discounts_nearby/discounts_controller.dart
@@ -10,11 +10,11 @@ class DiscountsController extends GetxController {
   final DiscountsRepository repository;
   final SettingsRepository settingsRepository;
 
-  final discounts = <DiscountDeal>[].obs;
-  final filterDistance = 20.0.obs;
-  final filterCategory = ''.obs;
-  final minDiscount = 0.0.obs;
-  final onlyOpenNow = false.obs;
+  final RxList<DiscountDeal> discounts = RxList<DiscountDeal>([]);
+  final RxDouble filterDistance = RxDouble(20.0);
+  final RxString filterCategory = RxString('');
+  final RxDouble minDiscount = RxDouble(0.0);
+  final RxBool onlyOpenNow = RxBool(false);
 
   @override
   void onInit() {

--- a/lib/modules/explore/explore_controller.dart
+++ b/lib/modules/explore/explore_controller.dart
@@ -17,12 +17,12 @@ class ExploreController extends GetxController {
   final DiscountsRepository discountsRepository;
   final SettingsRepository settingsRepository;
 
-  final auctions = <Auction>[].obs;
-  final products = <int, Product>{}.obs;
-  final discounts = <DiscountDeal>[].obs;
-  final filterType = ExploreFilter.both.obs;
-  final distanceLimit = 30.0.obs;
-  final selectedCategory = ''.obs;
+  final RxList<Auction> auctions = RxList<Auction>([]);
+  final RxMap<int, Product> products = RxMap<int, Product>({});
+  final RxList<DiscountDeal> discounts = RxList<DiscountDeal>([]);
+  final Rx<ExploreFilter> filterType = Rx<ExploreFilter>(ExploreFilter.both);
+  final RxDouble distanceLimit = RxDouble(30.0);
+  final RxString selectedCategory = RxString('');
 
   @override
   void onInit() {

--- a/lib/modules/favorites/favorites_controller.dart
+++ b/lib/modules/favorites/favorites_controller.dart
@@ -11,7 +11,7 @@ class FavoritesController extends GetxController {
   final WatchStoreRepository repository;
   final SettingsRepository settingsRepository;
 
-  final items = <WatchItem>[].obs;
+  final RxList<WatchItem> items = RxList<WatchItem>([]);
 
   @override
   void onInit() {

--- a/lib/modules/home/home_controller.dart
+++ b/lib/modules/home/home_controller.dart
@@ -16,17 +16,17 @@ class HomeController extends GetxController {
   static const int _pageSize = 6;
 
   final pagingController = PagingController<int, WatchItem>(firstPageKey: 0);
-  final activeCollection = 'all'.obs;
-  final searchQuery = ''.obs;
-  final appliedFilters = <String>[].obs;
-  final isRefreshing = false.obs;
-  final featuredItems = <WatchItem>[].obs;
+  final RxString activeCollection = RxString('all');
+  final RxString searchQuery = RxString('');
+  final RxList<String> appliedFilters = RxList<String>([]);
+  final RxBool isRefreshing = RxBool(false);
+  final RxList<WatchItem> featuredItems = RxList<WatchItem>([]);
   late final RxSet<int> favoriteIds;
   final TextEditingController searchFieldController = TextEditingController();
 
   @override
   void onInit() {
-    favoriteIds = settingsRepository.favoriteWatchIds.toSet().obs;
+    favoriteIds = RxSet<int>(settingsRepository.favoriteWatchIds.toSet());
     pagingController.addPageRequestListener(_fetchPage);
     _loadFeatured();
     super.onInit();

--- a/lib/modules/my_activity/my_activity_controller.dart
+++ b/lib/modules/my_activity/my_activity_controller.dart
@@ -12,9 +12,9 @@ class MyActivityController extends GetxController {
   final AuctionsRepository auctionsRepository;
   final DiscountsRepository discountsRepository;
 
-  final myAuctions = <Auction>[].obs;
-  final products = <int, Product>{}.obs;
-  final myDiscounts = <DiscountDeal>[].obs;
+  final RxList<Auction> myAuctions = RxList<Auction>([]);
+  final RxMap<int, Product> products = RxMap<int, Product>({});
+  final RxList<DiscountDeal> myDiscounts = RxList<DiscountDeal>([]);
 
   @override
   void onInit() {

--- a/lib/modules/notifications/notifications_controller.dart
+++ b/lib/modules/notifications/notifications_controller.dart
@@ -8,7 +8,7 @@ class NotificationsController extends GetxController {
 
   final NotificationsRepository repository;
 
-  final notifications = <NotificationItem>[].obs;
+  final RxList<NotificationItem> notifications = RxList<NotificationItem>([]);
 
   @override
   void onInit() {

--- a/lib/modules/onboarding/onboarding_controller.dart
+++ b/lib/modules/onboarding/onboarding_controller.dart
@@ -12,7 +12,7 @@ class OnboardingController extends GetxController {
   final WatchStoreRepository watchStoreRepository;
 
   final pageController = PageController();
-  final currentPage = 0.obs;
+  final RxInt currentPage = RxInt(0);
   late final List<String> slides;
 
   @override

--- a/lib/modules/price_watch/price_watch_controller.dart
+++ b/lib/modules/price_watch/price_watch_controller.dart
@@ -8,8 +8,8 @@ class PriceWatchController extends GetxController {
 
   final WatchesRepository repository;
 
-  final watches = <PriceWatch>[].obs;
-  final isLoading = false.obs;
+  final RxList<PriceWatch> watches = RxList<PriceWatch>([]);
+  final RxBool isLoading = RxBool(false);
 
   @override
   void onInit() {

--- a/lib/modules/profile/profile_controller.dart
+++ b/lib/modules/profile/profile_controller.dart
@@ -13,9 +13,9 @@ class ProfileController extends GetxController {
   final WatchStoreRepository repository;
 
   late final List<AppFeature> features;
-  final enabledFeatures = <String>{}.obs;
-  final recentlyViewed = <WatchItem>[].obs;
-  final recentSearches = <String>[].obs;
+  final RxSet<String> enabledFeatures = RxSet<String>({});
+  final RxList<WatchItem> recentlyViewed = RxList<WatchItem>([]);
+  final RxList<String> recentSearches = RxList<String>([]);
 
   @override
   void onInit() {

--- a/lib/modules/shell/shell_controller.dart
+++ b/lib/modules/shell/shell_controller.dart
@@ -8,7 +8,7 @@ class ShellController extends GetxController {
 
   final SettingsRepository settingsRepository;
 
-  final pageIndex = 0.obs;
+  final RxInt pageIndex = RxInt(0);
   final PageController pageController = PageController();
   final scaffoldKey = GlobalKey<ScaffoldState>();
 


### PR DESCRIPTION
## Summary
- replace the `.obs` extension usage in all controllers with explicit RxBool/RxInt/RxList and related types
- standardize reactive collection initialization using RxList, RxMap, and RxSet to improve type safety and readability
- keep existing business logic intact while aligning the codebase with the explicit GetX reactive pattern

## Testing
- Not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e269ade324832fb704a511246a2697